### PR TITLE
fix: rpc internal message

### DIFF
--- a/src/errors/handlers.ts
+++ b/src/errors/handlers.ts
@@ -119,6 +119,7 @@ export class RpcErrorHandler implements ErrorHandler {
   public handle(_data: string, { error }: ErrorHandlerErrorInfo): DecodedError {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const rpcError = error as any
-    return rpcErrorResult({ data: null, name: rpcError.code, reason: rpcError.message })
+    const reason = rpcError.info?.error?.message ?? rpcError.shortMessage ?? rpcError.message
+    return rpcErrorResult({ data: null, name: rpcError.code, reason })
   }
 }


### PR DESCRIPTION
This update fixes an issue with RPC error messages. It will also prioritise the long-form message over the short-form one and finally fall back on the error object message.