### PR TITLE
Fix "Cannot read properties of null (reading 'data')" issue when decoding error from ethers.js

### DIFF
--- a/src/error-decoder.ts
+++ b/src/error-decoder.ts
@@ -60,7 +60,7 @@ export class ErrorDecoder {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const errorData = (error as any).data ?? (error as any).error?.data
 
-    if (errorData === undefined) {
+    if (errorData === undefined || errorData === null) {
       return undefined
     }
 


### PR DESCRIPTION
The errorData could be null when the error is thrown from hardhat / ethers.js, hence a "Cannot read properties of null (reading 'data')" error will occur when setting returnData at line 67.

Example error causing the issue:

```
{
code: 'UNKNOWN_ERROR',
error: {
    code: -32000,
    message: "Nonce too high. Expected nonce to be 0 but got 33. Note that transactions can't be queued when automining.",
    data: {
      message: "Nonce too high. Expected nonce to be 0 but got 33. Note that transactions can't be queued when automining.",
      data: null <===  HERE is a null data!!!!
    }
  },
payload: {
    method: 'eth_sendRawTransaction',
    params: [
      '0x02f8b2827a6921843b9aca00843e9a078083015644944abeaca4b05d8fa4ced09d26ad28ea298e8afac880b844a9059cbb0000000000000000000000009965507d1a55bcc2695c58ba16fb37d819b0a4dc0000000000000000000000000000000000000000000000000000000000000064c001a03c032ec0cd43679f7400e1c90a8c9c07fe3d87ed4e0bf78ec5097046cf16d1eaa03cc5e482a939684ef216bfdeb72cb15fd36558a9df53de3745e3a27eb60f7869'
    ],
    id: 28,
    jsonrpc: '2.0'
  },
  shortMessage: 'could not coalesce error'
}
```